### PR TITLE
Fix paths in PictureConf

### DIFF
--- a/components/Picture.tsx
+++ b/components/Picture.tsx
@@ -3,7 +3,7 @@ import { makePicture } from 'sidepix/react';
 import { pictureConf } from './PictureConf';
 
 const pictureConfRef = {
-  filePath: resolve(__dirname, '../conf/PictureConf'),
+  filePath: resolve(__dirname, '../../../conf/PictureConf'),
   name: 'pictureConf',
 };
 

--- a/components/PictureConf.ts
+++ b/components/PictureConf.ts
@@ -6,13 +6,15 @@ import {
     formatToExtension,
     extensionToFormat,
   } from 'sidepix';
+
+import { resolve } from 'path';
   
   const fetch: FetchImage =
     typeof window === 'undefined'
       ? (src) => {
           const { createReadStream } = require('fs');
-          console.log(`../assets/${src}`);
-          return createReadStream(`../assets/${src}`);
+          console.log(resolve(__dirname, `../assets/${src}`));
+          return createReadStream(resolve(__dirname, `../assets/${src}`));
         }
       : () => {};
   


### PR DESCRIPTION
Hey, I debugged this by running `yarn sidepix-start` from a different terminal, so I could see the error messages.

It's actually always better to use `resolve(__dirname, ...` so you get absolute paths that are easier to debug. I'll fix that in the example in sidepix's repo.